### PR TITLE
fix plot control and checkbox bug

### DIFF
--- a/SlugHeat22_220928_working/plotLayout.m
+++ b/SlugHeat22_220928_working/plotLayout.m
@@ -403,7 +403,7 @@ elseif length(grid.RowHeight) == 2 && length(grid.ColumnWidth) == 1
     end
 end
 end
- % Nested function to turn visibility of axes' children OFF
+            % Nested function to turn visibility of axes' children OFF
             % ---------------------------------------------------------
              function axesChildrenOFF(C)
                     for k = 1:numel(C)


### PR DESCRIPTION
unchecked lines were being replotted when changing which plots are visible on penetration tab. now they are not plotted if they are already unchecked, plotted if checked